### PR TITLE
Update models and migrations (Event, Registration, Faculty, Major)

### DIFF
--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
@@ -33,5 +34,13 @@ class Event extends Model
     public function messages(): HasMany
     {
         return $this->hasMany(Message::class);
+    }
+    public function faculty(): BelongsTo
+    {
+        return $this->belongsTo(Faculty::class);
+    }
+    public function major(): BelongsTo
+    {
+        return $this->belongsTo(Major::class);
     }
 }

--- a/app/Models/Faculty.php
+++ b/app/Models/Faculty.php
@@ -17,4 +17,8 @@ class Faculty extends Model
     {
         return $this->hasMany(User::class);
     }
+    public function events(): HasMany
+    {
+        return $this->hasMany(Event::class);
+    }
 }

--- a/app/Models/Major.php
+++ b/app/Models/Major.php
@@ -18,4 +18,8 @@ class Major extends Model
     {
         return $this->hasMany(User::class);
     }
+    public function events(): HasMany
+    {
+        return $this->hasMany(Event::class);
+    }
 }

--- a/database/migrations/2024_12_03_051026_create_events_table.php
+++ b/database/migrations/2024_12_03_051026_create_events_table.php
@@ -19,7 +19,6 @@ return new class extends Migration
             $table->date('end_date');
             $table->string('group_chat_link');
             $table->string('job_description');
-            $table->string('poster');
             $table->timestamps();
         });
     }

--- a/database/migrations/2024_12_03_051915_create_registrations_table.php
+++ b/database/migrations/2024_12_03_051915_create_registrations_table.php
@@ -13,7 +13,8 @@ return new class extends Migration
     {
         Schema::create('registrations', function (Blueprint $table) {
             $table->id();
-            $table->dateTime('end_datetime');
+            $table->string('poster');
+            $table->enum('status', ['open', 'closed']);
             $table->timestamps();
         });
     }

--- a/database/migrations/2999_12_04_011609_update_tables_relations.php
+++ b/database/migrations/2999_12_04_011609_update_tables_relations.php
@@ -15,6 +15,10 @@ return new class extends Migration
             $table->foreignId('faculty_id')->references('id')->on('faculties')->onUpdate('cascade')->onDelete('cascade');
             $table->foreignId('major_id')->references('id')->on('majors')->onUpdate('cascade')->onDelete('cascade');
         });
+        Schema::table('events', function (Blueprint $table) {
+            $table->foreignId('faculty_id')->references('id')->on('faculties')->onUpdate('cascade')->onDelete('cascade');
+            $table->foreignId('major_id')->references('id')->on('majors')->onUpdate('cascade')->onDelete('cascade');
+        });
         Schema::table('organization_details', function (Blueprint $table) {
             $table->foreignId('user_id')->constrained();
         });


### PR DESCRIPTION
Attribute 'poster' moved to 'registrations' table instead of 'events' table. Registration now has attribute 'status' to replace 'end_datetime' (biar ngeclose sendiri oprecnya nanti panitia).  Table 'events' now belongs to a faculty and a major.